### PR TITLE
Fixing selector issue

### DIFF
--- a/src/components/menu-item/menu-item.style.scss
+++ b/src/components/menu-item/menu-item.style.scss
@@ -12,12 +12,12 @@
 
     &:hover {
       cursor: pointer;
-      &.background-image {
+      & .background-image { // You just need a space between the & and the .background-image selector.
         display: flex;
         transform: scale(1.2);
         transition: transform 6s cubic-bezier(0.25, 0.45, 0.45, 0.95);
       }
-      &.content {
+      & .content { // Similar to above
         opacity: 0.9;
       }
     }


### PR DESCRIPTION
For the orginal SASS that was here &.background-image is the same as writing `.menu-item.background-image`, which is looking for an element with both of the classes
`<div class='menu-item background-image'></div>`

The actual code you want to target is a div inside of the element with the `.menu-item` class. 
```
<div class='menu-item'>
   <div class='background-image'></div>
 </div>
```

In normal css to target the inner div you would write the selector as `.menu-item .background-image` with a space between the two classes.  Same applies here, the difference is the `&` is just a stand in `& .background-image` and it should hopefully work.